### PR TITLE
Switch to rendering locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ log
 ghostdriver.log
 ./src/ghostdriver.log
 ./src/__pychache__
+venv
 
 

--- a/help.txt
+++ b/help.txt
@@ -10,8 +10,8 @@ You can write compound words (noun + adjective) by concatenating the words. Not 
 
 `@tokipona_bot tokipona li pona tawa mi /`
 
-You can draw a rectangle for names by surrounding several words by \[ ] and adding a \_ before each word. Example:
+In some fonts, you can draw a rectangle for names by surrounding several words using \[ ].
 
-`@tokipona_bot ma [_kasi_alasa_nasin_awen_telo_a] li suli / `
+`@tokipona_bot ma [kasi alasa nasin awen telo a] li suli / `
 
 You can change the font and colors using /wilemi. Note that only the default font (Linja Pona - jan Same) is complete. Others may not let you write some words (like kin), or may not let you write Latin characters in the images. You can only write compound words with the default font.  [Code on Github](https://github.com/damaru2/tokipona_bot/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot
+pillow

--- a/sona.txt
+++ b/sona.txt
@@ -10,8 +10,8 @@ sina ken sitelen e nimi tu lon sitelen wan. o sitelen poka e ona a. sina ken ala
 
 `@tokipona_bot tokipona li pona tawa mi /`
 
-sina ken sitelen e poki tawa nimi jan tawa nimi ijo tawa nimi suli ante. o kepeken sitelen \[ ] en sitelen \_ lon poka nimi. sama ni:
+sina ken sitelen e poki tawa nimi jan tawa nimi ijo tawa nimi suli ante. o kepeken sitelen \[ ]. sama ni:
 
-`@tokipona_bot ma [_kasi_alasa_nasin_awen_telo_a] li suli / `
+`@tokipona_bot ma [kasi alasa nasin awen telo a] li suli / `
 
 sina ken ante e kule kepeken nasin /wilemi. o sona e ni a: nasin sitelen pi Linja Pona li ken ali. taso nasin ante li ken ala. nasin mute li ken ala sitelen e nimi pi pu ala li ken ala sitelen e sitelen Lasina lon sitelen li ken ala sitelen e nimi tu.

--- a/src/enums.py
+++ b/src/enums.py
@@ -46,12 +46,6 @@ class Fonts(Enum):
     toki_tengwar_jan_pije="9"
 
 
-    linja_pi_tomo_lipu="12"
-    linja_sike="17"
-    linja_suwi="18"
-    linja_pi_pu_lukin="19"
-
-
 fonts_dict = {
     Fonts.linja_pona_jan_same.value:                  "Linja Pona - jan Same",
     Fonts.linja_leko_jan_selano.value:                "Linja Leko - jan Selano",

--- a/src/enums.py
+++ b/src/enums.py
@@ -78,3 +78,12 @@ colors_dict = {
     Colors.pimeja_pimeja_pimeja_walo.value: "pimeja pimeja pimeja walo",
     Colors.walo.value: "walo",
 }
+
+
+pu = ["a", "akesi", "alasa", "anpa", "ante", "awen", "ala", "ali", "ale", "anu", "e", "en", "esun", "insa", "ijo", "ike", "ilo", "jaki", "jelo", "jan", "jo", "kalama", "kulupu", "kiwen", "kala", "kama", "kasi", "ken", "kepeken", "kili", "kule", "kute", "kon", "ko", "linja", "lukin", "lape", "laso", "lawa", "lete", "lili", "lipu", "loje", "luka", "lupa", "len", "lon", "la", "li", "monsi", "mama", "mani", "meli", "mije", "moku", "moli", "musi", "mute", "mun", "ma", "mi", "mu", "nanpa", "nasin", "nasa", "nena", "nimi", "noka", "ni", "oo", "olin", "open", "ona", "pakala", "palisa", "pimeja", "pilin", "pali", "pana", "pini", "pipi", "poka", "poki", "pona", "pan", "pi", "pu", "sitelen", "sijelo", "sinpin", "soweli", "sama", "seli", "selo", "seme", "sewi", "sike", "sina", "sona", "suli", "suno", "supa", "suwi", "sin", "tenpo", "taso", "tawa", "telo", "toki", "tomo", "tan", "tu", "utala", "unpa", "uta", "walo", "waso", "wawa", "weka", "wile", "wan"]
+
+
+ku_suli = ["epiku", "jasima", "kijetesantakalu", "kin", "kipisi", "kokosila", "ku", "lanpan", "leko", "meso", "misikeke", "monsuta", "n", "namako", "oko", "soko", "tonsi"]
+
+
+ku_lili = ["apeja", "ete", "ewe", "isipin", "kalamawala", "kan", "kapesi", "ke", "kese", "kiki", "kulijo", "kuntu", "likujo", "linluwi", "loka", "majuna", "misa", "mulapisu", "neja", "oke", "pake", "pata", "peto", "Pingo", "po", "polinpin", "pomotolo", "powe", "samu", "san", "soto", "sutopatikuna", "taki", "te", "teje", "to", "tuli", "umesu", "unu", "usawi", "waleja", "yupekosi"]

--- a/src/enums.py
+++ b/src/enums.py
@@ -42,6 +42,12 @@ class Fonts(Enum):
     toki_tengwar_jan_pije="9"
 
 
+    linja_pi_tomo_lipu="12"
+    linja_sike="17"
+    linja_suwi="18"
+    linja_pi_pu_lukin="19"
+
+
 fonts_dict = {
     Fonts.linja_pona_jan_same.value:                  "Linja Pona - jan Same",
     Fonts.linja_leko_jan_selano.value:                "Linja Leko - jan Selano",
@@ -51,6 +57,10 @@ fonts_dict = {
     Fonts.sitelen_pi_linja_ko_jan_inkepa.value:       "Linja Ko - jan Inkepa",
     Fonts.sitelen_pona_pona_jan_jaku.value:           "Sitelen Pona Pona - jan Jaku",
     Fonts.insa_pi_supa_lape_int_main.value:           "Insa Pi Supa Lape - jan int main();",
+    Fonts.linja_pi_tomo_lipu.value:                   "Linja Pi Tomo Lipu",
+    Fonts.linja_sike.value:                           "Linja Sike - jan Lipamanka",
+    Fonts.linja_suwi.value:                           "Linja Suwi - jan Anna",
+    Fonts.linja_pi_pu_lukin.value:                    "Linja Pi Pu Lukin - jan Sa",
 }
 
 colors_dict = {

--- a/src/enums.py
+++ b/src/enums.py
@@ -86,4 +86,5 @@ pu = ["a", "akesi", "alasa", "anpa", "ante", "awen", "ala", "ali", "ale", "anu",
 ku_suli = ["epiku", "jasima", "kijetesantakalu", "kin", "kipisi", "kokosila", "ku", "lanpan", "leko", "meso", "misikeke", "monsuta", "n", "namako", "oko", "soko", "tonsi"]
 
 
-ku_lili = ["apeja", "ete", "ewe", "isipin", "kalamawala", "kan", "kapesi", "ke", "kese", "kiki", "kulijo", "kuntu", "likujo", "linluwi", "loka", "majuna", "misa", "mulapisu", "neja", "oke", "pake", "pata", "peto", "Pingo", "po", "polinpin", "pomotolo", "powe", "samu", "san", "soto", "sutopatikuna", "taki", "te", "teje", "to", "tuli", "umesu", "unu", "usawi", "waleja", "yupekosi"]
+ku_lili = ["apeja", "ete", "ewe", "isipin", "kalamARR", "kalamawala", "kan", "kapesi", "ke", "kese", "kiki", "kulijo", "kuntu", "likujo", "linluwi", "loka", "majuna", "misa", "mulapisu", "neja", "oke", "pake", "pata", "peto", "Pingo", "po", "polinpin", "pomotolo", "powe", "samu", "san", "soto", "sutopatikuna", "taki", "te", "teje", "to", "tuli", "umesu", "unu", "usawi", "waleja", "yupekosi"]
+

--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# coding: utf-8
+# 
+# adapted from https://gist.github.com/josephkern/69591e9bc1d2e07a46d35d2a3ab66542
+# 
+# Copyright 2011 Álvaro Justen [alvarojusten at gmail dot com]
+# License: GPL <http://www.gnu.org/copyleft/gpl.html>
+
+from PIL import Image, ImageDraw, ImageFont
+
+font_cache = {}
+
+
+class ImageText(object):
+    def __init__(self, width, size, font_file, mode='RGBA', background=(0, 0, 0, 255),
+                 foreground = (255, 255, 251, 255), padding=10, padding_bottom=None, padding_top=None, padding_left=None, padding_right=None):
+        self.mode = mode
+        self.padding_top = padding_top or padding
+        self.padding_bottom = padding_bottom or padding
+        self.padding_left = padding_left or padding
+        self.padding_right = padding_right or padding
+        self.width = width
+        self.text_width = width - self.padding_left - self.padding_right
+        self.background = background
+        self.foreground = foreground
+        font_id = "{}#{}".format(font_file, size)
+        if font_id in font_cache:
+            self.font = font_cache[font_id]
+        else:
+            self.font = ImageFont.truetype(font_file, size)
+            font_cache[font_id] = self.font
+
+    def save(self, filename=None):
+        self.image.save(filename or self.filename)
+
+    def render(self, text, filename):
+        lines = self.wrap_text(text)
+        wrapped = '\n'.join(lines)
+        
+        text_size = self.font.getsize_multiline(wrapped)
+        height = text_size[1] + self.padding_top + self.padding_bottom
+        width = self.padding_left + self.padding_right + (text_size[0] if len(lines) == 1 else max(self.text_width, text_size[0]))
+
+        img = Image.new(self.mode, (width, height), color=self.background)
+        draw = ImageDraw.Draw(img)
+
+        draw.multiline_text((self.padding_left, self.padding_top), wrapped, font=self.font, fill=self.foreground)
+        img.save(filename)
+
+    def get_text_size(self, text):
+        return self.font.getsize(text)
+
+    def wrap_text(self, text):
+        hard_lines = text.split('\n')
+        lines = []
+        for hard_line in hard_lines:
+            line = []
+            words = hard_line.split()
+            for word in words:
+                new_line = ' '.join(line + [word])
+                size = self.get_text_size(new_line)
+                text_height = size[1]
+                if size[0] <= self.text_width:
+                    line.append(word)
+                else:
+                    word_size = self.get_text_size(word)
+                    if word_size[0] > self.text_width:
+                        lines.append(line)
+                        lines.append([word])
+                        line = []
+                    else:
+                        lines.append(line)
+                        line = [word]
+            if line:
+                lines.append(line)
+        lines = [' '.join(line) for line in lines if line]
+        return lines

--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -7,6 +7,7 @@
 # License: GPL <http://www.gnu.org/copyleft/gpl.html>
 
 from PIL import Image, ImageDraw, ImageFont
+import io
 
 font_cache = {}
 
@@ -30,10 +31,16 @@ class ImageText(object):
             self.font = ImageFont.truetype(font_file, size)
             font_cache[font_id] = self.font
 
-    def save(self, filename=None):
-        self.image.save(filename or self.filename)
+    def save(self, img, filename_or_format=None, binary=False):
+        if binary:
+            output = io.BytesIO()
+            img.save(output, format=filename_or_format)
+            return output.getvalue()
+        else:
+            img.save(filename_or_format or self.filename)
+            return filename_or_format
 
-    def render(self, text, filename):
+    def render(self, text, filename_or_format, binary=False):
         lines = self.wrap_text(text)
         wrapped = '\n'.join(lines)
         
@@ -45,7 +52,7 @@ class ImageText(object):
         draw = ImageDraw.Draw(img)
 
         draw.multiline_text((self.padding_left, self.padding_top), wrapped, font=self.font, fill=self.foreground)
-        img.save(filename)
+        return self.save(img, filename_or_format, binary)
 
     def get_text_size(self, text):
         return self.font.getsize(text)

--- a/src/private/private_conf.py.example
+++ b/src/private/private_conf.py.example
@@ -5,8 +5,6 @@ id_photo_help = "ID_OF_HELP_PHOTO"
 id_photo_nasin_sitelen = "ID_OF_FONT_PHOTO"
 id_photo_kule = "ID_OF_COLOR_PHOTO"
 
-render_directory = "/tmp" # Directory in which to store the temporary files created when rendering text
-
 fonts = {
     "default": "/path/to/your/linja-pona-4.9.otf",
     "1": "/path/to/your/linja-pona-4.9.otf",

--- a/src/private/private_conf.py.example
+++ b/src/private/private_conf.py.example
@@ -1,0 +1,23 @@
+token_id = "YOUR_TELEGRAM_BOT_TOKEN_HERE"
+magic_chat_id = chat_id_number
+
+id_photo_help = "ID_OF_HELP_PHOTO"
+id_photo_nasin_sitelen = "ID_OF_FONT_PHOTO"
+id_photo_kule = "ID_OF_COLOR_PHOTO"
+
+render_directory = "/tmp" # Directory in which to store the temporary files created when rendering text
+
+fonts = {
+    "default": "/path/to/your/linja-pona-4.9.otf",
+    "1": "/path/to/your/linja-pona-4.9.otf",
+    "2": "/path/to/your/linja_leko.ttf",
+    "3": "/path/to/your/sitelen_luka_tu_tu.otf",
+    "4": "/path/to/your/sitelen-pona.otf",
+    "10": "/path/to/your/linjapimeja1.4.ttf",
+    "12": "/path/to/your/linjapitomolipu.0.7.ttf",
+    "14": "/path/to/your/sitelen-pona-pona.otf",
+    "15": "/path/to/your/standard/supalape.otf",
+    "17": "/path/to/your/linja-sike-5.otf",
+    "18": "/path/to/your/linjasuwi.otf",
+    "19": "/path/to/your/PuLukin.otf",
+}


### PR DESCRIPTION
Hi! I made changes to your amazing bot to enable it to render the texts locally instead of using https://lp.plop.me/.

This is a fairly big change that affects the behavior of the bot in several cases. Let me know if you want it. I'm also happy to update this PR according to your wishes.

Cheers,
jan Alin / Jereviendrai / @alinea169 (Happy Catrahedron)

## Advantages
- No dependence on an external tool
- Translation to sitelen pona is handled by the font itself via ligatures. In this way, if the font knows how to render something, it will be rendered - there's no more dependence on the word being in the vocabulary list of either this bot or the lp.plop tool.
- Users can directly use glyph composition features if the font has them, enabling more compound words
- More direct control over the look of the rendered image (e.g. padding)
- Word wrapping logic can make use of the font rendering engine, enabling it to exactly figure out where the text should be wrapped.

## Disadvantages
- The transliteration now depends on the font, meaning the user will see subtle changes in the bot's behavior depending on the selected font (even more so than before).
- The pre-defined compound words (e.g. "tokipona") from lp.plop generally no longer work (or rather, work differently now) - but they usually still render as two separate sitelen pona glyphs, so it'll still be readable.
- By relying on font ligatures, it is no longer possible to leave non-Toki-Pona words alone. I.e. if a word contains a pu word, that part of the word will be turned into a sitelen pona glyph. Since "e", "o" and "a" are TP words, this affects almost every non-TP word. This can however be prevented by using uppercase letters for non-TP words.
    - This could be circumvented by using the TP dictionary to force-uppercase non-TP words, but then the advantage of not enforcing a specific word list is lost, so I decided against it - let me know if you disagree.
    - or alternatively, it might be possible to hack this using the font rendering library - if a word exceeds a certain width when rendered, it can't be a single sitelen pona glyph, therefore it is not available in this font and should be turned to uppercase. I am not sure how reliable this would be.
- The behavior of the bot changes in some cases (e.g. cartouches are written differently now, and compound glyphs work differently as well), which is always confusing for the user
- as we are now rendering images locally, the memory footprint of the bot might increase

## Other concerns
- I was able to keep this change compatible with the existing database schema. However, I was not able to obtain font files for all the fonts previously available (in particular, jan Inkepa seems to have disappeared from github and I can't find all their fonts elsewhere). I handled the case of suddenly missing fonts by falling back to Linja Pona as a default. So users who have selected a font that is now missing will see their font suddenly change.
- I updated the Telegram Bot SDK and changed the code to conform with the new method signatures. This means, if you wanted to run my changes, you'd likely have to update the python-telegram-bot library.
- I added just a little bit of padding at the bottom of the image, to work around the "time covers up the last few letters" issue. This can easily be configured or removed.
- I removed the "automatically lowercase all TP words" logic, because it allowed me to remove the word list. Personally I never had need for this feature, but if you disagree, it can easily be added back.

## Comparisons

![2022-02-18-192645-part](https://user-images.githubusercontent.com/7254040/154742024-41ba7681-de09-43d8-b7ab-6f64f76bf9a8.png)
Example sentence - word wrapping is different now but we could tweak the font size to get to 10 sitelen pona per line. Also, note how the word "Telegram" gets butchered now.

![2022-02-18-192623-part](https://user-images.githubusercontent.com/7254040/154742146-a251034e-278b-48c7-b837-fa515256de5a.png)
uppercase names are still left alone

![2022-02-18-192611-part](https://user-images.githubusercontent.com/7254040/154742200-af539e92-522b-4101-a303-32c5ebf9096a.png)
`sowelipona li pilin-pona` - compound glyphs now work differently

![2022-02-18-192134-part](https://user-images.githubusercontent.com/7254040/154742275-27c59d26-e067-4ebe-90e6-4c0e2e3e49f5.png)
`ma [kasi alasa nasin awen telo a] li suli` - cartouches work differently now

![2022-02-18-193053-part](https://user-images.githubusercontent.com/7254040/154742364-521269f2-0fdf-4873-81d9-63b78bc27781.png)
if the font has a ligature for a word then it gets converted correctly, automatically. (In this font, "yupekosi" and "n" are missing).

![2022-02-18-193153-part](https://user-images.githubusercontent.com/7254040/154742482-bc94240b-e979-44fe-bf38-a97aad1385d4.png)
even non-ku words work, given the font supports them. (linja sike has, like, everything)

